### PR TITLE
Fix brag list layout

### DIFF
--- a/src/BragsScreen/Brags.jsx
+++ b/src/BragsScreen/Brags.jsx
@@ -1,20 +1,33 @@
 import React from 'react'
 import { List, ListItem, ListItemIcon, Container } from '@material-ui/core'
 import { ChatBubbleRounded } from '@material-ui/icons'
+import { makeStyles } from '@material-ui/core/styles'
 
-const Brags = ({ brags }) => (
-  <Container>
-    <List>
-      {brags.map((brag, index) => (
-        <ListItem key={index}>
-          <ListItemIcon>
-            <ChatBubbleRounded />
-          </ListItemIcon>
-          {brag}
-        </ListItem>
-      ))}
-    </List>
-  </Container>
-)
+const Brags = ({ brags }) => {
+  const useStyles = makeStyles((theme) => ({
+    brag: {
+      wordBreak: 'break-all',
+    },
+  }))
+
+  const classes = useStyles()
+
+  return (
+    <Container>
+      <List>
+        {brags.map((brag, index) => (
+          <div class={classes.brag}>
+            <ListItem key={index}>
+              <ListItemIcon>
+                <ChatBubbleRounded />
+              </ListItemIcon>
+              {brag}
+            </ListItem>
+          </div>
+        ))}
+      </List>
+    </Container>
+  )
+}
 
 export default Brags

--- a/src/BragsScreen/__snapshots__/index.test.jsx.snap
+++ b/src/BragsScreen/__snapshots__/index.test.jsx.snap
@@ -101,7 +101,7 @@ exports[`BragsScreen Should match snapshot 1`] = `
       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        class="makeStyles-brags-6"
+        class="MuiContainer-root MuiContainer-maxWidthLg"
       >
         <ul
           class="MuiList-root MuiList-padding"


### PR DESCRIPTION
It appears that I was overriding the Container class to use the one that I created in the Brags component, It made the component to break the layout.

e.g:

![image](https://user-images.githubusercontent.com/11655576/83956571-ec55cb00-a835-11ea-8bc0-d84e224cae69.png)

Now It does not break the layout and we still break lines when the word gets too big:
e.g:

![image](https://user-images.githubusercontent.com/11655576/83956601-3a6ace80-a836-11ea-928b-a63d0a666738.png)
